### PR TITLE
Move syntax hilight language name to data-* attribute

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -64,7 +64,7 @@
 
         $('.im-coder-lang').click(function () {
 
-            var codeLang = $(this).text();
+            var codeLang = $(this).data('syntax-lang');
 
             var lang = 'langs/' + codeLang + '.txt';
 

--- a/index.html
+++ b/index.html
@@ -32,16 +32,16 @@
           <br>Or be a troll using for live coding in talks ;) </p>
       </header>
       <ul class="im-coder-langs">
-        <li class="im-coder-lang">c</li>
-        <li class="im-coder-lang">css</li>
-        <li class="im-coder-lang">go</li>
-        <li class="im-coder-lang">html</li>
-        <li class="im-coder-lang">java</li>
-        <li class="im-coder-lang">js</li>
-        <li class="im-coder-lang">perl</li>
-        <li class="im-coder-lang">php</li>
-        <li class="im-coder-lang">python</li>
-        <li class="im-coder-lang">ruby</li>
+        <li class="im-coder-lang" data-syntax-lang="c">C</li>
+        <li class="im-coder-lang" data-syntax-lang="css">CSS</li>
+        <li class="im-coder-lang" data-syntax-lang="go">Go</li>
+        <li class="im-coder-lang" data-syntax-lang="html">HTML</li>
+        <li class="im-coder-lang" data-syntax-lang="java">Java</li>
+        <li class="im-coder-lang" data-syntax-lang="js">JavaScript</li>
+        <li class="im-coder-lang" data-syntax-lang="perl">Perl</li>
+        <li class="im-coder-lang" data-syntax-lang="php">PHP</li>
+        <li class="im-coder-lang" data-syntax-lang="python">Python</li>
+        <li class="im-coder-lang" data-syntax-lang="ruby">Ruby</li>
         <li>
           <textarea id="im-coder-paste" class="im-coder-paste" placeholder="choose one language or paste a fake code here"></textarea>
         </li>


### PR DESCRIPTION
The current behavior is to get the language name from the text content of the node.
I believe it too fragile, because we can't add languages with more than 1 name (Visual Basic for instance) or with special characters (C# for instance).

My proposal is to transfer the "syntax language name" to a data-\* attribute.

I've also renamed all the current supported languages to their real name (with capital letters where applicable).
